### PR TITLE
fix: use local package in template

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -16,6 +16,8 @@ Important: ce dossier `template/` n’est pas inclus dans le paquet publié sur 
 ## Démarrage rapide
 1) Copier ce dossier `template/` hors du dépôt si besoin et renommer le répertoire selon votre projet.
 2) Dans `template/package.json`, adaptez le champ `name` (facultatif).
+   La dépendance `@state-of-geneva/rapports-bdd` pointe par défaut vers la racine du dépôt (`file:..`) pour les builds CI;
+   remplacez-la par une version publiée sur npm lorsque vous copiez ce dossier hors du repo.
 3) Placez vos fichiers `.feature` sous `template/features/` (voir Structures ci‑dessous).
 4) Depuis le dossier `template/` :
    - Installation: `npm install`

--- a/template/package.json
+++ b/template/package.json
@@ -11,7 +11,7 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "@state-of-geneva/rapports-bdd": "^1.0.12",
+    "@state-of-geneva/rapports-bdd": "file:..",
     "vite": "^5.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- avoid published package mismatch by using local path for template dev dependency
- document local dependency usage and npm replacement in template README

------
https://chatgpt.com/codex/tasks/task_e_68bae4160790832789e8ca9cc300d654